### PR TITLE
libretro: add webOS to Libretro CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,12 @@ include:
   # Nintendo 3DS
   #- project: 'libretro-infrastructure/ci-templates'
   #  file: '/ctr-static-cmake.yml'
-﻿
+
+  #################################### MISC ##################################
+  # webOS (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-cmake.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -138,3 +143,10 @@ libretro-build-tvos-arm64:
   #extends:
     #- .libretro-ctr-static-cmake-retroarch-master
     #- .core-defs
+
+#################################### MISC ####################################
+# webOS
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-cmake
+    - .core-defs


### PR DESCRIPTION
webOS core is now built by libretro buildbot