### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,6 +70,12 @@ libretro-build-linux-x64:
     - .libretro-linux-cmake-x86_64
     - .core-defs
 ﻿
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-defs
+﻿
 # Linux 32-bit
 libretro-build-linux-i686:
   extends:


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of DirkSimple, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: there is no x86-specific code or flag in the CMake build, and `android-arm64-v8a`, `osx-arm64`, `ios-arm64` and `tvos-arm64` already build these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-cmake-aarch64
    - .core-defs
```

No extra `include:` is needed - `.libretro-linux-cmake-aarch64` is defined inside `/linux-cmake.yml`, which this file already includes. (There is no `/linux-cmake-aarch64.yml` template; adding an include for it makes GitLab reject the whole config.) No `image:` override is needed either, exactly like the x64 job.

Verified natively on aarch64 (postmarketOS, glibc, GCC 15): `cmake -DLIBRETRO=ON` configures and builds clean with no source changes - including the bundled libtheora/libogg/libvorbis - producing `dirksimple_libretro.so` (ELF 64-bit ARM aarch64), and the core loads in a libretro host. I did not play a disc on it, since that needs a converted Dragon's Lair video I can't obtain here, so this is a build/load verification only.
